### PR TITLE
Replace hardcoded text values by localized defaults

### DIFF
--- a/lib/src/omni_datetime_picker.dart
+++ b/lib/src/omni_datetime_picker.dart
@@ -62,13 +62,23 @@ class _OmniDateTimePickerState extends State<OmniDateTimePicker>
   /// Initial value: Current DateTime
   DateTime startDateTime = DateTime.now();
 
+  late MaterialLocalizations _localizations;
+
   @override
   void initState() {
     if (widget.startInitialDate != null) {
       startDateTime = widget.startInitialDate!;
     }
 
+    _localizations = MaterialLocalizations.of(context);
+
     super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _localizations = MaterialLocalizations.of(context);
   }
 
   @override
@@ -168,7 +178,7 @@ class _OmniDateTimePickerState extends State<OmniDateTimePicker>
                         Navigator.of(context).pop<DateTime>();
                       },
                       child: Text(
-                        "Cancel",
+                        _localizations.cancelButtonLabel,
                         style: TextStyle(
                             color: widget.buttonTextColor ?? Colors.black),
                       ),
@@ -193,7 +203,7 @@ class _OmniDateTimePickerState extends State<OmniDateTimePicker>
                         );
                       },
                       child: Text(
-                        "Done",
+                        _localizations.saveButtonLabel,
                         style: TextStyle(
                             color: widget.buttonTextColor ?? Colors.black),
                       ),

--- a/lib/src/omni_datetime_range_picker.dart
+++ b/lib/src/omni_datetime_range_picker.dart
@@ -77,6 +77,7 @@ class OmniDateTimeRangePicker extends StatefulWidget {
 class _OmniDateTimeRangePickerState extends State<OmniDateTimeRangePicker>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
+  late MaterialLocalizations _localizations;
 
   /// startDateTime will be returned in a List<DateTime> with index 0
   ///
@@ -103,7 +104,15 @@ class _OmniDateTimeRangePickerState extends State<OmniDateTimeRangePicker>
       endDateTime = widget.endInitialDate!;
     }
 
+    _localizations = MaterialLocalizations.of(context);
+
     super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _localizations = MaterialLocalizations.of(context);
   }
 
   @override
@@ -145,7 +154,7 @@ class _OmniDateTimeRangePickerState extends State<OmniDateTimeRangePicker>
                             widget.borderRadius ?? const Radius.circular(16),
                       )),
                   child: Text(
-                    "Start",
+                    _localizations.dateRangeStartLabel,
                     style:
                         TextStyle(color: widget.tabTextColor ?? Colors.black87),
                   ),
@@ -165,7 +174,7 @@ class _OmniDateTimeRangePickerState extends State<OmniDateTimeRangePicker>
                             widget.borderRadius ?? const Radius.circular(16),
                       )),
                   child: Text(
-                    "End",
+                    _localizations.dateRangeEndLabel,
                     style:
                         TextStyle(color: widget.tabTextColor ?? Colors.black87),
                   ),
@@ -317,7 +326,7 @@ class _OmniDateTimeRangePickerState extends State<OmniDateTimeRangePicker>
                           Navigator.of(context).pop<List<DateTime>>();
                         },
                         child: Text(
-                          "Cancel",
+                          _localizations.cancelButtonLabel,
                           style: TextStyle(
                               color: widget.buttonTextColor ?? Colors.black),
                         ),
@@ -342,7 +351,7 @@ class _OmniDateTimeRangePickerState extends State<OmniDateTimeRangePicker>
                           ]);
                         },
                         child: Text(
-                          "Done",
+                          _localizations.saveButtonLabel,
                           style: TextStyle(
                               color: widget.buttonTextColor ?? Colors.black),
                         ),


### PR DESCRIPTION
Thank you for this well designed and lightweight library. 

In this PR, I propose we use localized default strings for the labels instead of hardcoded string values. 

The `MaterialLocalizations` class is also used in the official calendar_date_picker. The changes in this PR are analogous to the Google implementation. 

The "done" button text will be replaced by "save". I couldn't find a default "done" text, and I believe "save" to me more expressive anyway.